### PR TITLE
[FIX] the LoginFrame doesn't close correctly

### DIFF
--- a/src/main/java/fr/litarvan/openauth/microsoft/LoginFrame.java
+++ b/src/main/java/fr/litarvan/openauth/microsoft/LoginFrame.java
@@ -45,7 +45,7 @@ public class LoginFrame extends JFrame
         this.setTitle("Microsoft Authentication");
         this.setSize(750, 750);
         this.setLocationRelativeTo(null);
-
+        this.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
         this.setContentPane(new JFXPanel());
     }
 
@@ -78,6 +78,7 @@ public class LoginFrame extends JFrame
             if (newValue.contains("access_token")) {
                 this.setVisible(false);
                 this.future.complete(newValue);
+                this.dispose();
             }
         });
         webView.getEngine().setUserAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.113 Safari/537.36");

--- a/src/main/java/fr/litarvan/openauth/microsoft/LoginFrame.java
+++ b/src/main/java/fr/litarvan/openauth/microsoft/LoginFrame.java
@@ -59,7 +59,7 @@ public class LoginFrame extends JFrame
         this.addWindowListener(new WindowAdapter() {
             @Override
             public void windowClosing(WindowEvent e) {
-                future.completeExceptionally(new MicrosoftAuthenticationException("User closed the authentication window"));
+                future.complete(null);
             }
         });
 

--- a/src/main/java/fr/litarvan/openauth/microsoft/MicrosoftAuthenticator.java
+++ b/src/main/java/fr/litarvan/openauth/microsoft/MicrosoftAuthenticator.java
@@ -148,10 +148,14 @@ public class MicrosoftAuthenticator {
     public CompletableFuture<MicrosoftAuthResult> loginWithAsyncWebview() {
         String url = String.format("%s?%s", MICROSOFT_AUTHORIZATION_ENDPOINT, http.buildParams(getLoginParams()));
         LoginFrame frame = new LoginFrame();
-
         return frame.start(url).thenApplyAsync(result -> {
             try {
-                return loginWithTokens(extractTokens(result),true);
+                // it can happens if the window is closed too early
+                if (result != null) {
+                    return loginWithTokens(extractTokens(result),true);
+                } else {
+                    return null;
+                }
             } catch (MicrosoftAuthenticationException e) {
                 throw new CompletionException(e);
             }


### PR DESCRIPTION
[contributing]: https://github.com/azura-client/OpenAuth/blob/master/.github/CONTRIBUTING.md

## Pull Request Etiquette

- [x] I have checked the PRs for upcoming features/bug fixes.
- [x] I have read the [contributing guidelines][contributing].

### Changes

- [x] Internal code
- [ ] Documentation
- [ ] Other: \_____ <!-- Insert other type here -->

Closes Issue: NaN

## Description

There was a bug with the LoginFrame (used in loginWithWebview method of MicrosoftAuthenticator) which was not closed. This PR close it correctly in all cases (access token is retrieve or the user close the window before).
